### PR TITLE
Fix README for streaming write, #data => #each .

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ grid_fs.delete(f.id)
 
 g = grid_fs.get(f.id)
 g.data # big huge blob
-g.data{|chunk| file.write(chunk)} # streaming write
+g.each { |chunk| file.write(chunk) } # streaming write
 
 ```
 


### PR DESCRIPTION
The example given in README for 'streaming write' appears to be incorrect, with block not actually resulting in the data streaming. Instead, `#each` appears to yield the correct behaviour; this is what `#data` itself uses.

https://github.com/ahoward/mongoid-grid_fs/blob/master/lib/mongoid/grid_fs.rb#L323
https://github.com/ahoward/mongoid-grid_fs/blob/master/lib/mongoid/grid_fs.rb#L364

Peace,
tiredpixel