### PR TITLE
Added hint to use filename index

### DIFF
--- a/lib/mongoid/grid_fs.rb
+++ b/lib/mongoid/grid_fs.rb
@@ -204,8 +204,9 @@ require "mime/types"
             file_model.
               where(:filename => filename.to_s).
                 order_by(:uploadDate => :desc).
-                  limit(1).
-                    first
+                  hint(:filename => 1).
+                    limit(1).
+                      first
           end
 
           def []=(filename, readable)


### PR DESCRIPTION
In some cases mongodb query planner does not use filename index and scans by uploadDate which much slower. Using hint we can ensure that collection will be looked up by filename.