### PR TITLE
allow mime-types >= 3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .glimpse*
 .todo
+.ruby-version
 a.rb
 b.rb
 db/

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ cache: bundler
 rvm:
   - 2.1
   - 2.2
-  - jruby-19mode
+  - jruby-9.0.0.0
 gemfile:
   - Gemfile
   - gemfiles/mongoid-3.1.gemfile

--- a/mongoid-grid_fs.gemspec
+++ b/mongoid-grid_fs.gemspec
@@ -18,6 +18,6 @@ Gem::Specification::new do |spec|
   spec.require_path = "lib"
 
   spec.add_dependency "mongoid",    ">= 3.0", "< 6.0"
-  spec.add_dependency "mime-types", ">= 1.0", "< 3.0"
+  spec.add_dependency "mime-types", ">= 1.0", "< 4.0"
   spec.add_development_dependency "minitest", ">= 5.7.0", "< 6.0"
 end


### PR DESCRIPTION
Caveat: mime-types 3 drops support for Ruby 1.9