### PR TITLE
Mongoid 6.0 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,8 @@ gemfile:
   - gemfiles/mongoid-5.0.gemfile
 matrix:
   fast_finish: true
+
+env:
+  global:
+    env:
+      - RUBYOPT='-W0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,11 @@ gemfile:
   - gemfiles/mongoid-5.0.gemfile
 matrix:
   fast_finish: true
+  include:
+    - rvm: 2.2.2
+      gemfile: gemfiles/mongoid-6.0.gemfile
+    - rvm: 2.3.1
+      gemfile: gemfiles/mongoid-6.0.gemfile
 
 env:
   global:

--- a/gemfiles/mongoid-6.0.gemfile
+++ b/gemfiles/mongoid-6.0.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 5.0"
+gem "mongoid", "~> 6.0.0.beta"
+
+gemspec path: "../"

--- a/lib/mongoid/grid_fs.rb
+++ b/lib/mongoid/grid_fs.rb
@@ -100,8 +100,7 @@ require "mime/types"
           end
 
           def put(readable, attributes = {})
-            chunks = []
-            file = file_model.new
+            file = file_model.create
             attributes.to_options!
 
             if attributes.has_key?(:id)
@@ -147,12 +146,8 @@ require "mime/types"
               GridFs.chunking(io, chunkSize) do |buf|
                 md5 << buf
                 length += buf.size
-                chunk = file.chunks.build
-                chunk.data = binary_for(buf)
-                chunk.n = n
+                chunk = file.chunks.create(data: binary_for(buf), n: n)
                 n += 1
-                chunk.save!
-                chunks.push(chunk)
               end
             end
 
@@ -162,10 +157,9 @@ require "mime/types"
 
             file.update_attributes(attributes)
 
-            file.save!
             file
           rescue
-            chunks.each{|chunk| chunk.destroy rescue nil}
+            file.destroy
             raise
           end
 

--- a/mongoid-grid_fs.gemspec
+++ b/mongoid-grid_fs.gemspec
@@ -17,7 +17,7 @@ Gem::Specification::new do |spec|
   spec.test_files   = Dir["test/**/*"]
   spec.require_path = "lib"
 
-  spec.add_dependency "mongoid",    ">= 3.0", "< 6.0"
+  spec.add_dependency "mongoid",    ">= 3.0", "< 7.0"
   spec.add_dependency "mime-types", ">= 1.0", "< 4.0"
   spec.add_development_dependency "minitest", ">= 5.7.0", "< 6.0"
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -19,6 +19,8 @@ Mongoid.configure do |config|
   config.connect_to('mongoid-grid_fs_test')
 end
 
+Mongo::Logger.logger.level = Logger::INFO if defined?(Mongo) == 'constant'
+
 # Avoid annoying deprecation warning
 if I18n.respond_to?(:enforce_available_locales=)
   I18n.enforce_available_locales = false


### PR DESCRIPTION
This corrects a small association issue and hushes noisy log output for tests.

Previously chunks were being saved on a non-persisted file model in `#put` (this shouldn't have been working). With mongoid 6, stricter validation prevents chunks from being saved without a persisted file. Now the file model is persisted before chunks are saved. This removes the old chunks array since we can simply destroy the file model and its dependents upon rescue.

Ref #60